### PR TITLE
Add Permission Based Authorization

### DIFF
--- a/src/main/java/com/ine/backend/controllers/TestController.java
+++ b/src/main/java/com/ine/backend/controllers/TestController.java
@@ -11,27 +11,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/test")
 public class TestController {
 
-    @GetMapping("/user")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    public String user(){
-        return "user role";
+    @GetMapping("/events/read")
+    @PreAuthorize("hasAuthority('events:read')")
+    public String readAnyEvent(){
+        return "read any event";
     }
 
-    @GetMapping("/admin")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public String admin(){
-        return "admin role";
+    @GetMapping("/events/update-own-event")
+    @PreAuthorize("hasAuthority('events:update:self')")
+    public String updateOwnEvent(){
+        return "update own event";
     }
 
-    @GetMapping("/super-admin")
-    @PreAuthorize("hasRole('ROLE_SUPER_ADMIN')")
-    public String superAdmin(){
-        return "super admin role";
+    @GetMapping("/events/delete-own-event")
+    @PreAuthorize("hasAuthority('events:delete:self')")
+    public String deleteOwnEvent(){
+        return "delete own event";
     }
 
-    @GetMapping("/user-or-admin")
-    @PreAuthorize("hasAnyRole('ROLE_USER','ROLE_ADMIN')")
-    public String userOrAdmin(){
-        return "user or admin role";
-    }
 }

--- a/src/main/java/com/ine/backend/entities/Permission.java
+++ b/src/main/java/com/ine/backend/entities/Permission.java
@@ -1,0 +1,23 @@
+package com.ine.backend.entities;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public enum Permission {
+
+    // events permissions
+    EVENTS_READ("events:read"),
+    EVENTS_CREATE("events:create"),
+    EVENTS_UPDATE("events:update"),
+    EVENTS_UPDATE_SELF("events:update:self"),
+    EVENTS_DELETE("events:delete"),
+    EVENTS_DELETE_SELF("events:delete:self"),
+    ;
+
+    @Getter
+    private final String permission;
+}

--- a/src/main/java/com/ine/backend/entities/Role.java
+++ b/src/main/java/com/ine/backend/entities/Role.java
@@ -1,5 +1,52 @@
 package com.ine.backend.entities;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
 public enum Role {
-    ROLE_USER, ROLE_ADMIN, ROLE_SUPER_ADMIN
+    ROLE_USER(Set.of(
+            Permission.EVENTS_READ
+    )),
+    ROLE_ADMIN(Set.of(
+            Permission.EVENTS_READ,
+            Permission.EVENTS_CREATE,
+            Permission.EVENTS_UPDATE,
+            Permission.EVENTS_UPDATE_SELF,
+            Permission.EVENTS_DELETE_SELF
+    )),
+    ROLE_SUPER_ADMIN(Set.of(
+            Permission.EVENTS_READ,
+            Permission.EVENTS_CREATE,
+            Permission.EVENTS_UPDATE,
+            Permission.EVENTS_UPDATE_SELF,
+            Permission.EVENTS_DELETE,
+            Permission.EVENTS_DELETE_SELF
+    )),
+    // for example BDE, can only update and delete his own events that he created
+    ROLE_BDE(Set.of(
+             Permission.EVENTS_READ,
+             Permission.EVENTS_CREATE,
+             Permission.EVENTS_UPDATE_SELF,
+             Permission.EVENTS_DELETE_SELF
+    ));
+
+    @Getter
+    private final Set<Permission> permissions;
+
+    public List<SimpleGrantedAuthority> getAuthorities() {
+        var authorities = getPermissions()
+                .stream()
+                .map(permission -> new SimpleGrantedAuthority(permission.getPermission()))
+                .collect(Collectors.toList());
+
+        authorities.add(new SimpleGrantedAuthority(this.name()));
+        return authorities;
+    }
 }

--- a/src/main/java/com/ine/backend/security/UserDetailsImpl.java
+++ b/src/main/java/com/ine/backend/security/UserDetailsImpl.java
@@ -25,8 +25,7 @@ public class UserDetailsImpl implements UserDetails {
     private List<? extends GrantedAuthority> authorities;
 
     public static UserDetailsImpl build(User user){
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority(user.getRole().name() ));
+        List<SimpleGrantedAuthority> authorities = user.getRole().getAuthorities();
 
         return new UserDetailsImpl(
                 user.getId(),

--- a/src/main/java/com/ine/backend/services/AuthService.java
+++ b/src/main/java/com/ine/backend/services/AuthService.java
@@ -74,15 +74,16 @@ public class AuthService {
         String jwt = jwtUtils.generateJwtToken(authentication);
 
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-        List<String> roles = userDetails.getAuthorities().stream()
+        String role = userDetails.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.toList());
+                .filter(authority -> authority.startsWith("ROLE_"))
+                .findFirst().orElse(null);
 
         SignInResponseDto signInResponseDto = SignInResponseDto.builder()
                 .email(userDetails.getUsername())
                 .token(jwt)
                 .type("Bearer")
-                .role(Role.valueOf(roles.get(0)))
+                .role(Role.valueOf(role))
                 .build();
 
         return signInResponseDto;


### PR DESCRIPTION
## Issue
resolves #4 

## Description
Implemented role+permission based authorization, and Added some roles and permissions as an example for other ones.

- Each role has many permissions.
- A role is assigned to many users.

## Current roles:
    - ROLE_USER
    - ROLE_ADMIN
    - ROLE_SUPER_ADMIN
    - ROLE_BDE

## Current permissions (added the example only for events)
    - EVENTS_READ
    - EVENTS_CREATE
    - EVENTS_UPDATE (update any event)
    - EVENTS_UPDATE_SELF (permission to update only the events you created)
    - EVENTS_DELETE (delete any event)
    - EVENTS_DELETE_SELF (permission to delete only the events you created)

## Example: 
- `ROLE_BDE` have permissions `EVENTS_READ`, `EVENTS_CREATE`, `EVENTS_UPDATE_SELF`, `EVENTS_DELETE_SELF`. And this role is assigned to all DBE users. Notice that a BDE user can only update or delete his own events.
- `ROLE_USER` have permissions `EVENTS_READ`. And this role is assigned to all regular users.